### PR TITLE
Fixes cors in now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -30,8 +30,9 @@
     { "src": "/favicon.ico",
       "dest": "/static/favicon.ico"
     },
-    { "src": "/agreements/myagreements", 
-      "dest": "/api/my-agreements.js",
+    {
+      "src": "/(.*)",
+      "continue": true,
       "headers": {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept, Authorization",
@@ -39,6 +40,15 @@
         "Access-Control-Allow-Credentials": "true",
         "Access-Control-Max-Age": "3600"
       }
+    },
+    {
+      "src": "/(.*)",
+      "status": 200,
+      "methods": ["OPTIONS"]
+    },
+    { "src": "/agreements/myagreements", 
+      "dest": "/api/my-agreements.js",
+      "methods": ["GET"]
     },
     { "src": "/(.*)",
       "dest": "/README.html"


### PR DESCRIPTION
CORS has to be returned on every request (both OPTIONS and GET in this case).

But the OPTIONS request should not be passed to the code, so I added a little filter to just send an 200 ok! if it's an OPTIONS request.

GET requests get passed to the code as usual, but including the CORS headers.

The OPTIONS request is only used if it is not a "simple" request.
For [reference.](https://www.html5rocks.com/en/tutorials/cors/#toc-adding-cors-support-to-the-server)
